### PR TITLE
Check for nil before writing to file

### DIFF
--- a/pkg/pdfcpu/writeImage.go
+++ b/pkg/pdfcpu/writeImage.go
@@ -847,6 +847,9 @@ func RenderImage(xRefTable *XRefTable, sd *StreamDict, thumb bool, resourceName 
 
 // WriteReader consumes r's content by writing it to a file at path.
 func WriteReader(path string, r io.Reader) error {
+	if r == nil {
+		return errors.New("pdfcpu: WriteReader: Please provide r")
+	}
 	w, err := os.Create(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
While using the pdfcpu API to extract images from a database of documents, my program would periodically crash with a `SIGSEGV`.

Although I cannot share the exact document I was processing, I was able to reproduce this on my workstation CLI using the same document:

```console
$ pdfcpu extract -mode image complete_diss.pdf .
extracting images from complete_diss.pdf into ./ ...
writing complete_diss_049.png
writing complete_diss_095_Im0.tif
...
writing complete_diss_108_Im1.tif
writing complete_diss_114_Im0.
unexpected panic attack: runtime error: invalid memory address or nil pointer dereference
```

Checking for a nil `io.Reader` is a reasonable change to stop a program from completely crashing. However, I do suspect there is another bug somewhere in the image extraction mechanism.

Included are outputs from my server as well as the output of `pdfcpu validate`:

* [production.txt](https://github.com/j0hax/pdfcpu/files/9242831/production.txt)
* [validate.log](https://github.com/j0hax/pdfcpu/files/9242833/validate.log)
 